### PR TITLE
Fixed the bug which led to the violation of the max property

### DIFF
--- a/interval_tree.hpp
+++ b/interval_tree.hpp
@@ -806,18 +806,18 @@ private:
 
             // max fixup
             if (x->left_ && x->right_)
-                x->max_ = std::max(x->left_->max_, x->right_->max_);
+                x->max_ = std::max(x->max_, std::max(x->left_->max_, x->right_->max_));
             else if (x->left_)
-                x->max_ = x->left_->max_;
+                x->max_ = std::max(x->max_, x->left_->max_);
             else if (x->right_)
-                x->max_ = x->right_->max_;
+                x->max_ = std::max(x->max_, x->right_->max_);
             else
                 x->max_ = x->interval_.high_;
 
             if (y->right_)
-                y->max_ = std::max(y->right_->max_, x->max_);
+                y->max_ = std::max(y->max_, std::max(y->right_->max_, x->max_));
             else
-                y->max_ = x->max_;
+                y->max_ = std::max(y->max_, x->max_);
         }
 
         void right_rotate(node_type* y)
@@ -841,18 +841,18 @@ private:
 
             // max fixup
             if (y->left_ && y->right_)
-                y->max_ = std::max(y->left_->max_, y->right_->max_);
+                y->max_ = std::max(y->max_, std::max(y->left_->max_, y->right_->max_));
             else if (y->left_)
-                y->max_ = y->left_->max_;
+                y->max_ = std::max(y->max_, y->left_->max_);
             else if (y->right_)
-                y->max_ = y->right_->max_;
+                y->max_ = std::max(y->max_, y->right_->max_);
             else
                 y->max_ = y->interval_.high_;
 
             if (x->left_)
-                x->max_ = std::max(x->left_->max_, y->max_);
+                x->max_ = std::max(x->max_, std::max(x->left_->max_, y->max_));
             else
-                y->max_ = y->max_;
+                x->max_ = std::max(x->max_, y->max_);
         }
 
         void recalculate_max(node_type* reacalculation_root)


### PR DESCRIPTION
For the max property to hold, a node needs to select the highest max value from its left child, right child and own max value. As not all the max values (left/right/own) where considered after tree rotation, the max property was violated sometimes.
fixes: #2