### PR TITLE
Added recursive insert_overlap for single interval returns.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ int main()
   tree.insert({19, 20});
 
   tree.deoverlap();
-  
+
   for (auto const& i : tree)
   {
     std::cout << "[" << i.low() << ", " << i.high() << "]\n";
@@ -69,7 +69,7 @@ Creates an interval where the borders are sorted so the lower border is the firs
 
   - [Members of IntervalTree<Interval>](#members-of-intervaltreeinterval)
     - [iterator insert(interval_type const& ival)](#iterator-insertinterval_type-const-ival)
-    - [iterator insert_overlap(interval_type const& ival)](#iterator-insert_overlapinterval_type-const-ival)
+    - [iterator insert_overlap(interval_type const& ival, bool, bool)](#iterator-insert_overlapinterval_type-const-ival-bool-bool)
     - [iterator erase(iterator iter)](#iterator-eraseiterator-iter)
     - [size_type size() const](#size_type-size-const)
     - [(const)iterator find(interval_type const& ival)](#constiterator-findinterval_type-const-ival)
@@ -100,20 +100,20 @@ Creates an interval where the borders are sorted so the lower border is the firs
     - [reverse_iterator crend()](#reverse_iterator-crend)
 
 ### iterator insert(interval_type const& ival)
-Adds an interval into the tree. 
+Adds an interval into the tree.
 #### Parameters
 * `ival` An interval
 
 **Returns**: An iterator to the inserted element.
 
 ---
-### iterator insert_overlap(interval_type const& ival)
+### iterator insert_overlap(interval_type const& ival, bool, bool)
 Inserts an interval into the tree if no other interval overlaps it.
 Otherwise merge the interval with the one being overlapped.
 #### Parameters
 * `ival` An interval
 * `exclusive` Exclude borders from overlap check. Defaults to false.
-* `mergeSetOverlapping` If the result of interval::join is a collection of intervals, shall each be inserted with more overlap searches? Defaults to false
+* `recursive` If the result of interval::join is a collection of intervals, shall each be inserted with more overlap searches? If the result is a single interval, shall it be inserted via insert_overlap or insert? Defaults to false. recursive=true picks insert_overlap. Also be careful to not produce overlapping merge sets when doing recursive insertion, or it will recurse endlessly.
 
 **Returns**: An iterator to the inserted element.
 
@@ -325,7 +325,7 @@ Returns a past the end const_iterator in reverse.
 **Returns**: past the end const_iterator.
 
 ## Members of Interval
-___You can implement your own interval if you provide the same functions, except (within, operator-, size, operator!=).___
+___You can implement your own interval if you provide the same functions, except (operator-, size, operator!=).___
 
 There are 6 types of intervals:
 - open: (a, b)

--- a/include/interval-tree/feature_test.hpp
+++ b/include/interval-tree/feature_test.hpp
@@ -23,3 +23,21 @@
 #        define LIB_INTERVAL_TREE_FALLTHROUGH __attribute__((fallthrough))
 #    endif
 #endif
+
+// if constexpr is supported, use it, otherwise use plain if and pray the compiler optimizes it.
+#if __cplusplus >= 201703L
+#    define INTERVAL_TREE_CONSTEXPR_IF if constexpr
+#else
+#    define INTERVAL_TREE_CONSTEXPR_IF if
+#endif
+
+// enum { value = value_ } or static constexpr
+#if __cplusplus >= 201703L
+#    define INTERVAL_TREE_META_VALUE(type, name, the_value) static constexpr type name = the_value
+#else
+#    define INTERVAL_TREE_META_VALUE(type, name, the_value) \
+        enum : type \
+        { \
+            name = the_value \
+        }
+#endif

--- a/tests/insert_tests.hpp
+++ b/tests/insert_tests.hpp
@@ -7,19 +7,16 @@
 #include <random>
 #include <cmath>
 
-
-
-class InsertTests
-    : public ::testing::Test
+class InsertTests : public ::testing::Test
 {
-public:
-    using types = IntervalTypes <int>;
+  public:
+    using types = IntervalTypes<int>;
 
-protected:
-    IntervalTypes <int>::tree_type tree;
+  protected:
+    IntervalTypes<int>::tree_type tree;
     std::default_random_engine gen;
-    std::uniform_int_distribution <int> distSmall{-500, 500};
-    std::uniform_int_distribution <int> distLarge{-50000, 50000};
+    std::uniform_int_distribution<int> distSmall{-500, 500};
+    std::uniform_int_distribution<int> distLarge{-50000, 50000};
 };
 
 TEST_F(InsertTests, InsertIntoEmpty1)
@@ -86,15 +83,50 @@ TEST_F(InsertTests, RBPropertyInsertTest)
 
 TEST_F(InsertTests, IntervalsMayReturnMultipleIntervalsForJoin)
 {
-    using interval_type = multi_join_interval <int>;
+    using interval_type = multi_join_interval<int>;
     using tree_type = lib_interval_tree::interval_tree<interval_type>;
 
     auto multiJoinTree = tree_type{};
 
-    multiJoinTree.insert({0, 1});
-    multiJoinTree.insert_overlap({0, 2});
+    multiJoinTree.insert({0, 2});
+    multiJoinTree.insert_overlap({0, 4});
 
     EXPECT_EQ(multiJoinTree.size(), 2);
-    EXPECT_EQ(*multiJoinTree.begin(), (interval_type{0, 1})) << multiJoinTree.begin()->low() << multiJoinTree.begin()->high();
-    EXPECT_EQ(*++multiJoinTree.begin(), (interval_type{1, 2}));
+    EXPECT_EQ(*multiJoinTree.begin(), (interval_type{0, 1}))
+        << multiJoinTree.begin()->low() << multiJoinTree.begin()->high();
+    EXPECT_EQ(*++multiJoinTree.begin(), (interval_type{3, 4}));
+}
+
+TEST_F(InsertTests, IntervalsMayReturnMultipleIntervalsForJoinAndJoinRecursively)
+{
+    using interval_type = multi_join_interval<int>;
+    using tree_type = lib_interval_tree::interval_tree<interval_type>;
+
+    auto multiJoinTree = tree_type{};
+
+    multiJoinTree.insert({0, 10});
+    multiJoinTree.insert({5, 10});
+    multiJoinTree.insert_overlap({0, 20}, false, true);
+
+    EXPECT_EQ(multiJoinTree.size(), 3);
+
+    auto iter = multiJoinTree.begin();
+
+    EXPECT_EQ(*iter, (interval_type{0, 4})) << multiJoinTree.begin()->low() << multiJoinTree.begin()->high();
+    EXPECT_EQ(*++iter, (interval_type{6, 10})) << multiJoinTree.begin()->low() << multiJoinTree.begin()->high();
+    EXPECT_EQ(*++iter, (interval_type{11, 20})) << multiJoinTree.begin()->low() << multiJoinTree.begin()->high();
+}
+
+TEST_F(InsertTests, CanInsertOverlapRecursively)
+{
+    using tree_type = lib_interval_tree::interval_tree<types::interval_type>;
+
+    auto tree = tree_type{};
+    tree.insert({0, 9});
+    tree.insert({20, 29});
+    tree.insert_overlap({8, 21}, false, true);
+
+    EXPECT_EQ(tree.size(), 1);
+    EXPECT_EQ(tree.begin()->low(), 0);
+    EXPECT_EQ(tree.begin()->high(), 29);
 }

--- a/tests/multi_join_interval.hpp
+++ b/tests/multi_join_interval.hpp
@@ -7,32 +7,27 @@
 template <typename numerical_type, typename interval_kind_ = lib_interval_tree::closed>
 struct multi_join_interval
 {
-public:
+  public:
     using value_type = numerical_type;
     using interval_kind = interval_kind_;
 
-#ifndef INTERVAL_TREE_SAFE_INTERVALS
 #if __cplusplus >= 201703L
     constexpr
 #endif
-    multi_join_interval(value_type low, value_type high)
+        multi_join_interval(value_type low, value_type high)
         : low_{low}
         , high_{high}
     {
         if (low > high)
             throw std::invalid_argument("Low border is not lower or equal to high border.");
     }
-#else
-#if __cplusplus >= 201703L
-    constexpr
-#endif
-    multi_join_interval(value_type low, value_type high)
-        : low_{std::min(low, high)}
-        , high_{std::max(low, high)}
-    {
-    }
-#endif
+
     virtual ~multi_join_interval() = default;
+    multi_join_interval(multi_join_interval const&) = default;
+    multi_join_interval(multi_join_interval&&) noexcept = default;
+    multi_join_interval& operator=(multi_join_interval const&) = default;
+    multi_join_interval& operator=(multi_join_interval&&) noexcept = default;
+
     friend bool operator==(multi_join_interval const& lhs, multi_join_interval const& other)
     {
         return lhs.low_ == other.low_ && lhs.high_ == other.high_;
@@ -91,13 +86,13 @@ public:
         const auto min = std::min(low_, other.low_);
         const auto max = std::max(high_, other.high_);
         const auto avg = (min + max) / 2;
-        return {
-            {min, avg},
-            {avg, max},
+        return std::vector<multi_join_interval>{
+            multi_join_interval{min, avg - 1},
+            multi_join_interval{avg + 1, max},
         };
     }
 
-protected:
+  protected:
     value_type low_;
     value_type high_;
 };


### PR DESCRIPTION
Turns `insert_overlap(interval, exclusive, overlap_merge_set)` into `insert_overlap(interval, exclusive, recursive)`
and documents it.

Making also single interval insertions recursive if wanted.